### PR TITLE
Fix multivalue in match expression

### DIFF
--- a/internal/provider/workload_policy_target.go
+++ b/internal/provider/workload_policy_target.go
@@ -645,7 +645,7 @@ func (m *LabelSelector) fromProto(selector *apiv1.LabelSelector) {
 		m = &LabelSelector{}
 	}
 	m.MatchLabels = types.MapValueMust(types.StringType, fromStringMap(selector.MatchLabels))
-	m.MatchExpressions = types.ListValueMust(types.StringType, fromElementList(selector.MatchExpressions, MatchExpression{}.AttrTypes()))
+	m.MatchExpressions = types.ListValueMust(types.ObjectType{AttrTypes: MatchExpression{}.AttrTypes()}, fromElementList(selector.MatchExpressions, MatchExpression{}.AttrTypes()))
 }
 
 func (m *RegexPattern) fromProto(pattern *apiv1.RegexPattern) {

--- a/internal/provider/workload_policy_target.go
+++ b/internal/provider/workload_policy_target.go
@@ -644,7 +644,13 @@ func (m *LabelSelector) fromProto(selector *apiv1.LabelSelector) {
 	if m == nil {
 		m = &LabelSelector{}
 	}
-	m.MatchLabels = types.MapValueMust(types.StringType, fromStringMap(selector.MatchLabels))
+
+	// Handle match_labels: if empty, set to null instead of empty map
+	if len(selector.MatchLabels) == 0 {
+		m.MatchLabels = types.MapNull(types.StringType)
+	} else {
+		m.MatchLabels = types.MapValueMust(types.StringType, fromStringMap(selector.MatchLabels))
+	}
 
 	// Manually convert match expressions from proto to Terraform types
 	var matchExpressions []attr.Value
@@ -681,7 +687,12 @@ func (m *LabelSelector) fromProto(selector *apiv1.LabelSelector) {
 		matchExpressions = append(matchExpressions, matchExpr)
 	}
 
-	m.MatchExpressions = types.ListValueMust(types.ObjectType{AttrTypes: MatchExpression{}.AttrTypes()}, matchExpressions)
+	// Handle match_expressions: if empty, set to null instead of empty list
+	if len(matchExpressions) == 0 {
+		m.MatchExpressions = types.ListNull(types.ObjectType{AttrTypes: MatchExpression{}.AttrTypes()})
+	} else {
+		m.MatchExpressions = types.ListValueMust(types.ObjectType{AttrTypes: MatchExpression{}.AttrTypes()}, matchExpressions)
+	}
 }
 
 func (m *RegexPattern) fromProto(pattern *apiv1.RegexPattern) {

--- a/internal/provider/workload_policy_target.go
+++ b/internal/provider/workload_policy_target.go
@@ -645,7 +645,43 @@ func (m *LabelSelector) fromProto(selector *apiv1.LabelSelector) {
 		m = &LabelSelector{}
 	}
 	m.MatchLabels = types.MapValueMust(types.StringType, fromStringMap(selector.MatchLabels))
-	m.MatchExpressions = types.ListValueMust(types.ObjectType{AttrTypes: MatchExpression{}.AttrTypes()}, fromElementList(selector.MatchExpressions, MatchExpression{}.AttrTypes()))
+
+	// Manually convert match expressions from proto to Terraform types
+	var matchExpressions []attr.Value
+	for _, expr := range selector.MatchExpressions {
+		// Convert operator enum to string
+		var operatorStr string
+		switch expr.Operator {
+		case apiv1.LabelSelectorOperator_LABEL_SELECTOR_OPERATOR_IN:
+			operatorStr = "In"
+		case apiv1.LabelSelectorOperator_LABEL_SELECTOR_OPERATOR_NOT_IN:
+			operatorStr = "NotIn"
+		case apiv1.LabelSelectorOperator_LABEL_SELECTOR_OPERATOR_EXISTS:
+			operatorStr = "Exists"
+		case apiv1.LabelSelectorOperator_LABEL_SELECTOR_OPERATOR_DOES_NOT_EXIST:
+			operatorStr = "DoesNotExist"
+		case apiv1.LabelSelectorOperator_LABEL_SELECTOR_OPERATOR_GT:
+			operatorStr = "Gt"
+		case apiv1.LabelSelectorOperator_LABEL_SELECTOR_OPERATOR_LT:
+			operatorStr = "Lt"
+		}
+
+		// Convert values to Terraform list
+		values := types.ListValueMust(types.StringType, fromStringList(expr.Values))
+
+		// Build the match expression object
+		matchExpr := types.ObjectValueMust(
+			MatchExpression{}.AttrTypes(),
+			map[string]attr.Value{
+				"key":      types.StringValue(expr.Key),
+				"operator": types.StringValue(operatorStr),
+				"values":   values,
+			},
+		)
+		matchExpressions = append(matchExpressions, matchExpr)
+	}
+
+	m.MatchExpressions = types.ListValueMust(types.ObjectType{AttrTypes: MatchExpression{}.AttrTypes()}, matchExpressions)
 }
 
 func (m *RegexPattern) fromProto(pattern *apiv1.RegexPattern) {

--- a/internal/provider/workload_policy_target_test.go
+++ b/internal/provider/workload_policy_target_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	apiv1 "github.com/devzero-inc/terraform-provider-devzero/internal/gen/api/v1"
 )
 
 func TestWorkloadPolicyTargetResourceSchema(t *testing.T) {
@@ -302,6 +304,27 @@ func TestWorkloadPolicyTargetResourceModel(t *testing.T) {
 		}
 		if len(proto.Values) != 2 {
 			t.Errorf("Expected 2 values, got %d", len(proto.Values))
+		}
+	})
+
+	// Test LabelSelector with empty collections returns null
+	t.Run("LabelSelector_EmptyCollectionsToNull", func(t *testing.T) {
+		// Create a proto selector with empty match labels and expressions
+		proto := &apiv1.LabelSelector{
+			MatchLabels:      map[string]string{},
+			MatchExpressions: []*apiv1.LabelSelectorRequirement{},
+		}
+
+		// Convert from proto
+		selector := &LabelSelector{}
+		selector.fromProto(proto)
+
+		// Verify that empty collections are converted to null
+		if !selector.MatchLabels.IsNull() {
+			t.Errorf("Expected match_labels to be null, got %v", selector.MatchLabels)
+		}
+		if !selector.MatchExpressions.IsNull() {
+			t.Errorf("Expected match_expressions to be null, got %v", selector.MatchExpressions)
 		}
 	})
 

--- a/internal/provider/workload_policy_target_test.go
+++ b/internal/provider/workload_policy_target_test.go
@@ -123,6 +123,140 @@ func TestWorkloadPolicyTargetResourceModel(t *testing.T) {
 		}
 	})
 
+	// Test LabelSelector with multiple MatchExpressions and multiple values
+	t.Run("LabelSelector_WithMultipleMatchExpressions", func(t *testing.T) {
+		selector := &LabelSelector{
+			MatchLabels: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"app":         types.StringValue("web"),
+				"environment": types.StringValue("production"),
+			}),
+			MatchExpressions: types.ListValueMust(
+				types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"key":      types.StringType,
+						"operator": types.StringType,
+						"values":   types.ListType{ElemType: types.StringType},
+					},
+				},
+				[]attr.Value{
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"key":      types.StringType,
+							"operator": types.StringType,
+							"values":   types.ListType{ElemType: types.StringType},
+						},
+						map[string]attr.Value{
+							"key":      types.StringValue("tier"),
+							"operator": types.StringValue("In"),
+							"values": types.ListValueMust(types.StringType, []attr.Value{
+								types.StringValue("frontend"),
+								types.StringValue("backend"),
+								types.StringValue("middleware"),
+							}),
+						},
+					),
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"key":      types.StringType,
+							"operator": types.StringType,
+							"values":   types.ListType{ElemType: types.StringType},
+						},
+						map[string]attr.Value{
+							"key":      types.StringValue("region"),
+							"operator": types.StringValue("NotIn"),
+							"values": types.ListValueMust(types.StringType, []attr.Value{
+								types.StringValue("us-east-1"),
+								types.StringValue("us-west-1"),
+							}),
+						},
+					),
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"key":      types.StringType,
+							"operator": types.StringType,
+							"values":   types.ListType{ElemType: types.StringType},
+						},
+						map[string]attr.Value{
+							"key":      types.StringValue("version"),
+							"operator": types.StringValue("Exists"),
+							"values":   types.ListValueMust(types.StringType, []attr.Value{}),
+						},
+					),
+				},
+			),
+		}
+
+		// Test toProto
+		ctx := context.Background()
+		proto, err := selector.toProto(ctx)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if proto == nil {
+			t.Fatal("Expected non-nil proto")
+		}
+		if len(proto.MatchLabels) != 2 {
+			t.Errorf("Expected 2 match labels, got %d", len(proto.MatchLabels))
+		}
+		if proto.MatchLabels["app"] != "web" {
+			t.Errorf("Expected app=web, got %s", proto.MatchLabels["app"])
+		}
+		if proto.MatchLabels["environment"] != "production" {
+			t.Errorf("Expected environment=production, got %s", proto.MatchLabels["environment"])
+		}
+		if len(proto.MatchExpressions) != 3 {
+			t.Fatalf("Expected 3 match expressions, got %d", len(proto.MatchExpressions))
+		}
+
+		// Check first expression (In with multiple values)
+		expr1 := proto.MatchExpressions[0]
+		if expr1.Key != "tier" {
+			t.Errorf("Expected key=tier, got %s", expr1.Key)
+		}
+		if expr1.Operator != 1 { // IN = 1
+			t.Errorf("Expected operator=IN (1), got %d", expr1.Operator)
+		}
+		if len(expr1.Values) != 3 {
+			t.Errorf("Expected 3 values, got %d", len(expr1.Values))
+		}
+		expectedTiers := []string{"frontend", "backend", "middleware"}
+		for i, expected := range expectedTiers {
+			if expr1.Values[i] != expected {
+				t.Errorf("Expected value[%d]='%s', got '%s'", i, expected, expr1.Values[i])
+			}
+		}
+
+		// Check second expression (NotIn with multiple values)
+		expr2 := proto.MatchExpressions[1]
+		if expr2.Key != "region" {
+			t.Errorf("Expected key=region, got %s", expr2.Key)
+		}
+		if expr2.Operator != 2 { // NOT_IN = 2
+			t.Errorf("Expected operator=NOT_IN (2), got %d", expr2.Operator)
+		}
+		if len(expr2.Values) != 2 {
+			t.Errorf("Expected 2 values, got %d", len(expr2.Values))
+		}
+		expectedRegions := []string{"us-east-1", "us-west-1"}
+		for i, expected := range expectedRegions {
+			if expr2.Values[i] != expected {
+				t.Errorf("Expected value[%d]='%s', got '%s'", i, expected, expr2.Values[i])
+			}
+		}
+
+		// Check third expression (Exists with no values)
+		expr3 := proto.MatchExpressions[2]
+		if expr3.Key != "version" {
+			t.Errorf("Expected key=version, got %s", expr3.Key)
+		}
+		if expr3.Operator != 3 { // EXISTS = 3
+			t.Errorf("Expected operator=EXISTS (3), got %d", expr3.Operator)
+		}
+		if len(expr3.Values) != 0 {
+			t.Errorf("Expected 0 values for Exists operator, got %d", len(expr3.Values))
+		}
+	})
+
 	// Test RegexPattern
 	t.Run("RegexPattern", func(t *testing.T) {
 		pattern := &RegexPattern{

--- a/internal/provider/workload_policy_target_test.go
+++ b/internal/provider/workload_policy_target_test.go
@@ -384,8 +384,14 @@ func TestWorkloadPolicyTargetResourceModel(t *testing.T) {
 
 		// Verify each match expression
 		for i, origElem := range original.MatchExpressions.Elements() {
-			origObj := origElem.(types.Object)
-			convObj := converted.MatchExpressions.Elements()[i].(types.Object)
+			origObj, ok := origElem.(types.Object)
+			if !ok {
+				t.Fatalf("Expected original match expression %d to be types.Object", i)
+			}
+			convObj, ok := converted.MatchExpressions.Elements()[i].(types.Object)
+			if !ok {
+				t.Fatalf("Expected converted match expression %d to be types.Object", i)
+			}
 
 			if !origObj.Equal(convObj) {
 				t.Errorf("Match expression %d doesn't match after round-trip", i)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for label selectors covering multiple match expressions, multiple values, empty-collection handling, and round-trip conversion to ensure fidelity between representations.

* **Bug Fixes**
  * Improved parsing/serialization of complex label selection so match expressions are emitted and restored as structured objects and empty collections are represented as null where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->